### PR TITLE
Update libraries/smtp.php

### DIFF
--- a/libraries/smtp.php
+++ b/libraries/smtp.php
@@ -46,7 +46,7 @@ class SMTP
 	public function __construct($connection = null)
 	{
 		// load config
-		$config = Config::get('smtp');
+		$config = Config::get('smtp::smtp');
 	
 		// if no connection...
 		if (!$connection)


### PR DESCRIPTION
Config:get requires following structure for config file argument: 'bundle_name:configfile_name'.
Otherwise, $config will be NULL and it will lead to an error in class constructor.
