### PR TITLE
Fixes for Date: and To: headers

### DIFF
--- a/libraries/smtp.php
+++ b/libraries/smtp.php
@@ -344,6 +344,7 @@ class SMTP
 		$headers[] = 'From: '.$this->format($this->from);
 		$headers[] = 'Reply-To: '.$this->format($this->reply ? $this->reply : $this->from);
 		$headers[] = 'Subject: '.$this->subject;
+		$headers[] = 'Date: '.date("r");
 		
 		// add to receipients
 		if (!empty($this->to))
@@ -560,7 +561,7 @@ class SMTP
 		}
 		else
 		{
-			return $recipient['email'];
+			return '<' . $recipient['email'] . '>';
 		}
 	}
 }


### PR DESCRIPTION
SpamAssasin will throw high warnings if the Date: header isn't included, or if the email address isn't properly formatted. While technically allowed in in the RFC, the out of the box SpamAssassin setup deployed on many servers penalizes emails that lack the <> around the To: header. See TO_NO_BRKTS_DIRECT.
